### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kachaparth/my-blog-practice/security/code-scanning/2](https://github.com/kachaparth/my-blog-practice/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow uses the `github-tag-action` to push tags, it requires `contents: write` permission. We will add a `permissions` block at the root level of the workflow to apply these permissions to all jobs. This ensures that the workflow has only the necessary permissions and no more.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
