### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/kachaparth/my-blog-practice/security/code-scanning/1](https://github.com/kachaparth/my-blog-practice/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function. Since the workflow only installs dependencies and runs tests, it does not require any write permissions. The minimal permission required is `contents: read`, which allows the workflow to read the repository contents.

The `permissions` block will be added at the top level of the workflow, ensuring it applies to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
